### PR TITLE
Add early expiry functionality with 15 minute default

### DIFF
--- a/authenticator.go
+++ b/authenticator.go
@@ -14,6 +14,9 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 )
 
+// DefaultEarlyExpiry is used by NewAuthenticator when earlyExpiry is unspecified
+var DefaultEarlyExpiry = 15 * time.Minute
+
 type ecrClient interface {
 	GetAuthorizationToken(ctx context.Context, params *ecr.GetAuthorizationTokenInput, optFns ...func(*ecr.Options)) (*ecr.GetAuthorizationTokenOutput, error)
 }
@@ -68,6 +71,12 @@ func (authenticator *ecrAuthenticator) Authorization() (*authn.AuthConfig, error
 }
 
 // NewAuthenticator returns a new Authenticator instance from the given ECR client.
-func NewAuthenticator(client *ecr.Client, earlyExpiry time.Duration) authn.Authenticator {
+func NewAuthenticatorWithEarlyExpiry(client *ecr.Client, earlyExpiry time.Duration) authn.Authenticator {
 	return &ecrAuthenticator{client: client, earlyExpiry: earlyExpiry}
 }
+
+// NewAuthenticator returns a new Authenticator instance from the given ECR client.
+func NewAuthenticator(client *ecr.Client) authn.Authenticator {
+	return NewAuthenticatorWithEarlyExpiry(client, DefaultEarlyExpiry)
+}
+

--- a/authenticator.go
+++ b/authenticator.go
@@ -70,7 +70,7 @@ func (authenticator *ecrAuthenticator) Authorization() (*authn.AuthConfig, error
 	return authConfig, nil
 }
 
-// NewAuthenticator returns a new Authenticator instance from the given ECR client.
+// NewAuthenticatorWithEarlyExpiry returns a new Authenticator instance with a custom earlyExpiry value.
 func NewAuthenticatorWithEarlyExpiry(client *ecr.Client, earlyExpiry time.Duration) authn.Authenticator {
 	return &ecrAuthenticator{client: client, earlyExpiry: earlyExpiry}
 }


### PR DESCRIPTION
Add functionality to treat tokens as-if they expired earlier than declared in the response from AWS to account for clock drift. By default this is now 15 minutes (of a 12 hour token) but can be customized to anything else.